### PR TITLE
Fixing self-supervised dataset example

### DIFF
--- a/examples/python/librispeech_selfsupervised.py
+++ b/examples/python/librispeech_selfsupervised.py
@@ -110,7 +110,7 @@ class ChainRunner:
                        'rate': 16000.0,
                        'bits_per_sample': 32}
 
-        y, sampling_rate = self.chain.apply(
+        y = self.chain.apply(
             x, src_info=src_info, target_info=target_info)
 
         # sox might misbehave sometimes by giving nan/inf if sequences are too short (or silent)


### PR DESCRIPTION
Sampling rate is no longer returned, but the example code does expect it.

Fixes https://github.com/facebookresearch/WavAugment/issues/10